### PR TITLE
Minor cleanups

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -50,7 +50,7 @@ function deserialize(query) {
 
   prevent_hash_update = true;
   $('#locale').val(options.locale);
-  $('#auto_plurals').attr('checked', !!options.auto_plurals);
+  $('#auto_plurals').attr('checked', !!options.autoPlurals);
   $('#strict').attr('checked', !!options.strict);
   editor.setValue(options.s ? options.s : '');
 
@@ -109,7 +109,7 @@ function _change(rebuild_params) {
     if (rebuild_params) {
       options = {
         'locale': $('#locale').val(),
-        'auto_plurals': !!$('#auto_plurals').attr('checked'),
+        'autoPlurals': !!$('#auto_plurals').attr('checked'),
         'strict': false,
         'callback': cb,
       };
@@ -133,7 +133,7 @@ function _change(rebuild_params) {
 
     options = {
       'locale': $('#locale').val(),
-      'auto_plurals': !!$('#auto_plurals').attr('checked'),
+      'autoPlurals': !!$('#auto_plurals').attr('checked'),
       'strict': !!$('#strict').attr('checked'),
     };
 

--- a/js/plurr.js
+++ b/js/plurr.js
@@ -29,7 +29,7 @@
     var defaultOptions = options || {};
     addMissingOptions(defaultOptions, {
       'locale': 'en',
-      'auto_plurals': true,
+      'autoPlurals': true,
       'strict': true
     });
 
@@ -211,7 +211,7 @@
       addMissingOptions(options, defaultOptions);
 
       var strict = !!options.strict;
-      var autoPlurals = !!options.auto_plurals;
+      var autoPlurals = !!options.autoPlurals;
       var callback = options.callback;
 
       var chunks = s.split(/([\{\}])/);

--- a/js/plurr.js
+++ b/js/plurr.js
@@ -205,14 +205,14 @@
       options = options || {};
 
       var pluralFunc = options.locale != "" ?
-        pluralEquations[options.locale] || pluralEquations['en'] :
+        pluralEquations[options.locale] || pluralEquations.en :
         this.plural;
 
       addMissingOptions(options, defaultOptions);
 
-      var strict = !!options['strict'];
-      var autoPlurals = !!options['auto_plurals'];
-      var callback = options['callback'];
+      var strict = !!options.strict;
+      var autoPlurals = !!options.auto_plurals;
+      var callback = options.callback;
 
       var chunks = s.split(/([\{\}])/);
       var blocks = [''];
@@ -320,7 +320,7 @@
     }; // function format
 
     // initialize with the provided or default locale ('en')
-    this.locale(defaultOptions['locale'] || 'en');
+    this.locale(defaultOptions.locale || 'en');
   }
 
   return Plurr;

--- a/js/plurr.js
+++ b/js/plurr.js
@@ -28,9 +28,9 @@
 
     var defaultOptions = options || {};
     addMissingOptions(defaultOptions, {
-      'locale': 'en',
-      'autoPlurals': true,
-      'strict': true
+      locale: 'en',
+      autoPlurals: true,
+      strict: true
     });
 
     //


### PR DESCRIPTION
Some minor cleanups. Note `auto_plurals` has been renamed to `autoPlurals` so it feels more natural in JS land (demo adjusted accordingly).