### PR TITLE
Add missing options early on

### DIFF
--- a/js/plurr.js
+++ b/js/plurr.js
@@ -203,12 +203,11 @@
       }
 
       options = options || {};
+      addMissingOptions(options, defaultOptions);
 
       var pluralFunc = options.locale != "" ?
         pluralEquations[options.locale] || pluralEquations['en'] :
         this.plural;
-
-      addMissingOptions(options, defaultOptions);
 
       var strict = !!options['strict'];
       var autoPlurals = !!options['auto_plurals'];


### PR DESCRIPTION
This fixes a bug where the plural function would be set to English even if the
Plurr constructor already defined a different locale to use.