### PR TITLE
Fix fallback to English

### DIFF
--- a/python/plurr.py
+++ b/python/plurr.py
@@ -201,10 +201,12 @@ class Plurr(object):
         if not isinstance(options, dict):
             raise TypeError(u"'options' is not a dict")
 
-        try:
-            plural_func = self._plural_equations.get(options['locale'], 'en')
-        except KeyError:
-            plural_func = self._plural
+        plural_func = self._plural
+        if 'locale' in options:
+            try:
+                plural_func = self._plural_equations[options['locale']]
+            except KeyError:
+                plural_func = self._plural_equations['en']
 
         self.add_missing_options(options, self._default_options)
 

--- a/python/t/rendering.py
+++ b/python/t/rendering.py
@@ -77,3 +77,10 @@ t('7.2', p, s, {'N': 5}, {'locale': 'en'}, u'Удалить эти 5 файла 
 t('7.3', p, s, {'N': 5}, None, u'Удалить эти 5 файлов навсегда?')
 p.set_locale('en');
 t('7.4', p, s, {'N': 5}, None, u'Удалить эти 5 файла навсегда?')
+
+# Test for locale overrides and fallback
+s = 'Test {N_PLURAL:Foo|Bar {N}}'
+p = Plurr({'locale': 'ru'})
+p._plural_equations['foo-bar'] = lambda n: 1 if (n != 2) else 0
+t('8.1', p, s, {'N': 2}, {'locale': 'foo-bar'}, 'Test Foo')
+t('8.2', p, s, {'N': 2}, {'locale': 'foo_BAR'}, 'Test Bar 2')


### PR DESCRIPTION
The previous code would return the 'en' string in case the locale specified as
an argument couldn't be found.