### PR TITLE
Remove trailing comma in pluralEquations object

### DIFF
--- a/js/plurr.js
+++ b/js/plurr.js
@@ -183,7 +183,7 @@
       'wa': function(n) { return (n>1) ? 1 : 0; }, // Walloon
 
       'zh': function(n) { return 0; }, // Chinese
-      'zh-personal': function(n) { return (n>1) ? 1 : 0; }, // Chinese, used in special cases when dealing with personal pronoun
+      'zh-personal': function(n) { return (n>1) ? 1 : 0; } // Chinese, used in special cases when dealing with personal pronoun
     };
 
     //


### PR DESCRIPTION
Although most JS bundlers will remove it, trailing commas will cause
runtime errors in IE7 and below.