### PR TITLE
Added error for non-existing locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ language requirements. Plurr formatters are implemented in:
 **Go, Java, JavaScript, Perl, PHP, and Python**. Feel free to contribute
 to this project and provide support for your favorite languages.
 
+The plural forms we use can be found at the [Translate Project page](http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html).
+
 [Try live demo &rarr;](http://iafan.github.io/plurr-demo/)
 ===============
 

--- a/go/plurr/errors.go
+++ b/go/plurr/errors.go
@@ -28,7 +28,7 @@ var ErrEmptyPlaceholderName = errors.New("Empty placeholder name")
 var ErrEmptyListOfVariants = errors.New("Empty list of variants")
 
 // ErrPlaceholderValueNotDefined is returned by Format function
-// when neither palaceholder not its prefix variant (sans '_PLURAL')
+// when neither placeholder not its prefix variant (sans '_PLURAL')
 // is not defined
 type PlaceholderValueNotDefinedError struct {
 	name   string

--- a/js/plurr.js
+++ b/js/plurr.js
@@ -191,6 +191,9 @@
     // Choose the plural function based on locale name
     //
     this.setLocale = function(locale) {
+      if (!(locale in pluralEquations)) {
+        throw new TypeError("Unknown locale '" + locale + "'");
+      }
       this.plural = pluralEquations[locale];
     }; // function locale
 

--- a/php/Plurr.php
+++ b/php/Plurr.php
@@ -182,6 +182,9 @@ class Plurr {
   // Choose the plural function based on locale name
   //
   public function set_locale($locale) {
+    if (!(array_key_exists($locale, $this->plural_equations))) {
+      throw new Exception("Unknown locale '" . $locale . "'");
+    }
     $this->plural = $this->plural_equations[$locale];
   } // function locale
 

--- a/python/plurr.py
+++ b/python/plurr.py
@@ -189,8 +189,11 @@ class Plurr(object):
 
     def set_locale(self, locale):
         """Choose the plural function based on locale name."""
-        self._plural = self._plural_equations[locale]
-        # TODO: raise error on missing locale
+        try:
+            self._plural = self._plural_equations[locale]
+        except KeyError:
+            if strict:
+                raise KeyError(u"Unkown locale '"+ locale +"'")
 
     def format(self, s, params, options=None):
         if options is None:


### PR DESCRIPTION
Helps address issue #15

I haven't tested yet so uncertain if ready for merge.

I also wanted to ask it seems the Go implementation is different in that the `SetLocale` function handles the fallback to English whereas the other implementations simply have the `format` function handle the fallback. Not sure which makes more sense?