### PR TITLE
php/Plurr.php::__construct 'options' is incorrectly treated as an object property

### DIFF
--- a/php/Plurr.php
+++ b/php/Plurr.php
@@ -175,7 +175,7 @@ class Plurr {
     );
 
     // initialize with the provided or default locale ('en')
-    $this->set_locale(defined($this->options['locale']) ? $this->options['locale'] : 'en');
+    $this->set_locale($this->default_options['locale']);
   } // function __construct
 
   //


### PR DESCRIPTION
In the constructor, $this->options needs changing to $this->default_options (as it is, the 'en' locale will always be chosen as $this->options is undefined).